### PR TITLE
fix(color): correct OkLab cubic transformation using Vector3.Transform

### DIFF
--- a/color/oklab_test.go
+++ b/color/oklab_test.go
@@ -1,0 +1,36 @@
+package color
+
+import "testing"
+
+func TestOkLabRoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		argb ARGB
+	}{
+		{"black", 0xFF000000},
+		{"white", 0xFFFFFFFF},
+		{"red", 0xFFFF0000},
+		{"green", 0xFF00FF00},
+		{"blue", 0xFF0000FF},
+		{"yellow", 0xFFFFFF00},
+		{"cyan", 0xFF00FFFF},
+		{"magenta", 0xFFFF00FF},
+		{"gray", 0xFF808080},
+		{"random", 0xFF123456},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			oklab := tt.argb.ToXYZ().ToOkLab()
+			t.Log(oklab)
+			got := oklab.ToXYZ().ToARGB()
+			if tt.argb != got {
+				t.Errorf(
+					"Failed OkLab round-trip! Source %s, Returned %s",
+					tt.argb.String(),
+					got.String(),
+				)
+			}
+		})
+	}
+}

--- a/color/xyz.go
+++ b/color/xyz.go
@@ -55,6 +55,12 @@ func (c XYZ) ToLab() Lab {
 	return NewLab(l, a, b)
 }
 
+// ToOkLab convets XYZ to OkLan color model
+func (c XYZ) ToOkLab() OkLab {
+	x, y, z := c.Values()
+	return OkLabFromXYZ(x, y, z)
+}
+
 // ToCam converts XYZ to color appearance model (Cam16)
 func (c XYZ) ToCam() *Cam16 {
 	return Cam16FromXyzInEnv(c, &DefaultEnviroment)

--- a/num/matrix.go
+++ b/num/matrix.go
@@ -93,6 +93,18 @@ func NewVector3(x, y, z float64) Vector3 {
 	return Vector3{x, y, z}
 }
 
+// Transform returns a new Vector3 where each component of v has been
+// transformed by the given func f. The func f is applied to each of v's
+// components independently, producing a new Vector3 without modifying the
+// original.
+func (v Vector3) Transform(f func(float64) float64) Vector3 {
+	var result Vector3
+	for i := range 3 {
+		result[i] = f(v[i])
+	}
+	return result
+}
+
 // MultiplyMatrix multiply Vector3 with given Matrix3.
 func (v Vector3) MultiplyMatrix(m Matrix3) Vector3 {
 	var result Vector3


### PR DESCRIPTION
Previously, the cubic root transformation in OkLabFromXYZ incorrectly
reapplied `math.Cbrt` to the same variable (`p`), causing incorrect
color conversion results.

This commit:
- Replaces manual component-wise cubic operations with
  `Vector3.Transform`.
- Fixes the cubic root and cube transformations in OkLab <-> XYZ
  conversions.
- Adds `OkLab.String()` for improved debug output.
- Introduces table-driven round-trip tests for OkLab conversion.
- Adds `XYZ.ToOkLab()` helper.
- Implements `Vector3.Transform()` in num/matrix.go for reusable
  per-component transformations.

These changes ensure numerical correctness and cleaner functional
composition in OkLab color operations.

Resolves: #3
